### PR TITLE
Back to nickel

### DIFF
--- a/kobo/koreader.sh
+++ b/kobo/koreader.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 export LC_ALL="en_US.UTF-8"
 
+# environment needed to run nickel
+export LD_LIBRARY_PATH=/usr/local/Kobo
+export QWS_MOUSE_PROTO="tslib_nocal:/dev/input/event1"
+export QWS_KEYBOARD=imx508kbd:/dev/input/event0
+export QWS_DISPLAY=Transformed:imx508:Rot90
+
 # we're always starting from our working directory
 cd /mnt/onboard/.kobo/koreader/
 
@@ -10,36 +16,29 @@ export TESSDATA_PREFIX="data"
 # export dict directory
 export STARDICT_DATA_DIR="data/dict"
 
-# stop Nickel
-killall -STOP nickel
-
-# store the content of the framebuffer
-#dd if=/dev/fb0 of=.last_screen_content
+# stop kobo main applications and fmon execution
+# fmon is running while nickel is running just for exit from nickel.
+# we don't need fmon in koreader but we need to be sure to enable it after koreader execution.
+killall nickel
+killall hindenburg
+killall fmon
 
 # finally call reader
 ./reader.lua /mnt/onboard 2> crash.log
 
-# continue with nickel
-killall -CONT nickel
+# back to nickel again
+/usr/local/Kobo/pickel disable.rtc.alarm
+/sbin/hwclock -s -u
 
-# return to home screen
-case `/bin/kobo_config.sh * 2>/dev/null` in
-	dragon)		#DEVICE=AURAHD
-				#no binary file available
-		;;
-	phoenix)	#DEVICE=AURA
-				cat ./KoboAuraTapHomeIcon.bin > /dev/input/event1
-				cat ./KoboAuraTapHomeIcon.bin > /dev/input/event1
-		;;
-	kraken)		#DEVICE=GLO
-				#no binary file available
-		;;
-	pixie)		#DEVICE=MINI
-				cat ./KoboMiniTapHomeIcon.bin > /dev/input/event1
-				cat ./KoboMiniTapHomeIcon.bin > /dev/input/event1
-		;;
-	trilogy|*)	#DEVICE=TOUCH
-				cat ./KoboTouchHomeButton.bin > /dev/input/event0
-		;;
-esac
+# we need to feed up fmon; disabled right now
+# this means fmon will be able to exit from nickel once
+
+echo 1 > /sys/devices/platform/mxc_dvfs_core.0/enable
+
+if [ ! -e /etc/wpa_supplicant/wpa_supplicant.conf ]; then
+    cp /etc/wpa_supplicant/wpa_supplicant.conf.template /etc/wpa_supplicant/wpa_supplicant.conf
+fi
+
+/usr/local/Kobo/nickel -qws -skipFontLoad
+
 


### PR DESCRIPTION
OK, this time it does the exactly same procedure used by tshrering on his scripts (on .kobo/kbmenu/onstart/startreader.sh) to start nickel, but first kill nickel (as in .kobo/kbmenu/onstart/killnickel.sh) and runs koreader until exit :) 

I hope this works.
Thanks for all your tests but it is sufficient if you start the script from shell (through ssh) while nickel is running (even if nickel is started from start menu)
